### PR TITLE
Add ability to compute transit times and expansion points in the same integration

### DIFF
--- a/src/Photodynamics.jl
+++ b/src/Photodynamics.jl
@@ -6,7 +6,7 @@ using Reexport
 using StaticArrays, LinearAlgebra, Roots, SpecialFunctions, Limbdark
 
 import Limbdark: transit_poly_g, transit_poly_g!, Transit_Struct
-import NbodyGradient: InitialConditions, Derivatives, ElementsIC
+import NbodyGradient: InitialConditions, Derivatives, ElementsIC, TransitOutput
 import NbodyGradient: check_step, set_state!
 
 export dot, compute_lightcurve!

--- a/src/simpson.jl
+++ b/src/simpson.jl
@@ -75,13 +75,7 @@ function integrate_simpson!(a::T, b::T, f::Function, ia::IntegralArrays{T}) wher
         A[j,2] = h * (g[j,1] + 4 * g[j,2] + g[j,3])
         A[j,3] = h * (g[j,3] + 4 * g[j,4] + g[j,5])
     end
-    maxdiff = zero(T)
-    @inbounds for j = 1:nf
-        maxa231 = abs((A[j,2] + A[j,3]) - A[j,1])
-        if maxa231 > maxdiff
-            maxdiff = maxa231
-        end
-    end
+    maxdiff = abs((A[1,2] + A[1,3]) - A[1,1])
     if maxdiff > 3 * epsilon
         m *= 2
         n += 1

--- a/test/common.jl
+++ b/test/common.jl
@@ -6,6 +6,8 @@ import Photodynamics: IntegralArrays, integrate_simpson!
 import Photodynamics: integrate_timestep!, compute_flux, compute_flux!
 import Photodynamics: NbodyGradient.amatrix
 
+isapprox_maxabs(a,b) = isapprox(a, b, norm=x->maximum(abs.(x)))
+
 function setup_ICs(n, BJD::T, t0::T) where T<:Real
     elements = T.(readdlm("elements.txt", ',')[1:n,:])
     elements[2:end,3] .-= BJD # Shift initial transit times
@@ -30,6 +32,14 @@ function compute_transit_times(ic, intr; grad=false)
     tt = TransitTiming(intr.tmax, ic)
     intr(s, tt; grad=grad)
     return tt
+end
+
+function compute_pd(ic, intr; grad=false)
+    s = State(ic);
+    tt = TransitTiming(intr.tmax, ic);
+    pd = TransitSeries(intr.tmax, ic);
+    intr(s, pd, tt;grad=grad)
+    return pd
 end
 
 function compute_pd(ic, tt, intr; grad=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,12 @@ using Test
 include("common.jl")
 
 @testset "Photodynamics.jl" begin
+    print("Integration Methods... ")
+    @testset "Integration Methods" begin
+        include("test_transit_series.jl")
+    end
+    println("Done.")
+
     print("Impact Parameter... ")
     @testset "Impact Parameter" begin
         include("test_impact_parameter.jl")

--- a/test/test_transit_series.jl
+++ b/test/test_transit_series.jl
@@ -1,0 +1,24 @@
+function test_integrator_methods(n)
+    # Setup and run the simulation
+    BJD = 7250.0; t0_ic = 7.0
+    tmax = 100.0
+    ic = setup_ICs(n,BJD,t0_ic)
+    intr = setup_integrator(ic, tmax)
+    tt = compute_transit_times(ic, intr)
+    pd_provided = compute_pd(ic, tt, intr)
+    pd_computed = compute_pd(ic, intr);
+
+    @test pd_provided.times == pd_computed.times
+    @test pd_provided.bodies == pd_computed.bodies
+
+    # Computed points array is likely longer than provided
+    t_range = length(pd_provided.times)
+    @test pd_provided.points ≈ pd_computed.points[:,1:t_range,:,:]
+
+    # Make sure there's no extra computed points
+    @test all(pd_computed.points[:,t_range+1:end,:,:] .== 0.0)
+end
+
+@testset "Integrator Methods" begin
+    test_integrator_methods(8)
+end


### PR DESCRIPTION
## Main changes:
- Adds ability to either:
  1. pass a set of transit times (ie. from an `NbodyGradient` output), and then integrate and compute expansion points, or 
  2. to compute both the transit times and expansion points during the same nbody integration. 
- Corresponding updates to tests.

### Misc changes: 
1. Fix Simpson integration to only refine on flux, rather than derivatives as well.
3. Remove transit time 'refinement' -- not needed with addition of transit times + expansion points method
4. Fix static vector typing in `points_of_contact_X`