### PR TITLE
Refactor Lightcurve

### DIFF
--- a/src/Photodynamics.jl
+++ b/src/Photodynamics.jl
@@ -10,7 +10,7 @@ import NbodyGradient: InitialConditions, Derivatives, ElementsIC, TransitOutput
 import NbodyGradient: check_step, set_state!
 
 export dot, compute_lightcurve!
-export TransitSeries, Lightcurve
+export TransitSeries, Lightcurve, dLightcurve
 export transform_to_elements!
 export get_transit_times, get_linear_transit_times
 

--- a/test/test_compute_flux.jl
+++ b/test/test_compute_flux.jl
@@ -82,7 +82,7 @@ function test_compute_timestep_derivatives(n)
             ki = ib - 1
             trans_grad = transit_init(k[ki], 0.0, u_n, true)
             n_params = length(dbdq0) + length(k) + length(u_n) + 1 # flux
-            lc = Lightcurve(0.0, [0.0], [0.0], [0.0], u_n, k, rstar, 7*(length(k)+1))
+            lc = dLightcurve(0.0, [0.0], [0.0], [0.0], u_n, k, rstar)
             compute_flux!(texp, t0, xc, yc, dxc, dyc, lc, trans_grad, 1, ki, inv(rstar))
 
             # Check flux again

--- a/test/test_compute_lightcurve.jl
+++ b/test/test_compute_lightcurve.jl
@@ -23,7 +23,7 @@ function test_lightcurve(n)
     tobs = collect(pd.times[1]-10*intr.h:dt:obs_duration)
     lc = Lightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
     lc_noint = Lightcurve(0.0, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
-    dlc = Lightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar, n * 7)
+    dlc = dLightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
     compute_lightcurve!(lc, pd_provided, tol=1e-11, maxdepth=40)
     compute_lightcurve!(lc, pd_computed, tol=1e-11, maxdepth=40)
 
@@ -45,8 +45,8 @@ function test_lightcurve(n)
     haskey(ENV, "CI") ? println("\nProvided - Computed: ", maximum(abs.(lc_p.flux .- lc_c.flux))) : nothing
     @test isapprox_maxabs(lc_p.flux, lc_c.flux)
 
-    dlc_p = Lightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar, n * 7)
-    dlc_c = Lightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar, n * 7)
+    dlc_p = dLightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
+    dlc_c = dLightcurve(dt, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
     compute_lightcurve!(dlc_p, pd_provided, tol=1e-11, maxdepth=40)
     compute_lightcurve!(dlc_c, pd_computed, tol=1e-11, maxdepth=40)
     haskey(ENV, "CI") ? println("dProvided - dComputed: ", maximum(abs.(dlc_p.flux .- dlc_c.flux))) : nothing
@@ -58,7 +58,7 @@ function test_lightcurve(n)
     @test isapprox_maxabs(dlc_c.flux, lc_c.flux)
 
     lc_noint = Lightcurve(0.0, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
-    dlc_noint = Lightcurve(0.0, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar, n * 7)
+    dlc_noint = dLightcurve(0.0, copy(tobs), copy(tobs), zeros(length(tobs)), u_n, k, rstar)
     compute_lightcurve!(lc_noint, pd_computed, tol=1e-11, maxdepth=40)
     compute_lightcurve!(dlc_noint, pd_computed, tol=1e-11, maxdepth=40)
     haskey(ENV, "CI") ? println("dnoint - noint: ", maximum(abs.(dlc_noint.flux .- lc_noint.flux))) : nothing
@@ -104,7 +104,7 @@ function test_jacobians(n)
     cadence = 2 / 60 / 24  # 2 minute cadence in days
     obs_duration = 2.0  # Duration of observations in days
     obs_times = collect(t0:cadence:obs_duration)
-    lc_noint = Lightcurve(0.0, obs_times, ones(length(obs_times)), zeros(length(obs_times)), u_n, k, rstar, 7*n)
+    lc_noint = dLightcurve(0.0, obs_times, ones(length(obs_times)), zeros(length(obs_times)), u_n, k, rstar)
     #lc_int = Lightcurve(cadence, obs_times, ones(length(obs_times)), zeros(length(obs_times)), u_n, k, rstar, 7*n)
  
     # Compute the dynamical model

--- a/test/test_lightcurve.jl
+++ b/test/test_lightcurve.jl
@@ -10,9 +10,17 @@ function test_lightcurve_constructors(n)
     lc1 = Lightcurve(dt, tobs, zeros(size(tobs)), zeros(size(tobs)), u_n, k, rstar)
     lc2 = Lightcurve(dt, obs_duration, u_n, k, rstar)
 
+    dlc1 = dLightcurve(dt, tobs, zeros(size(tobs)), zeros(size(tobs)), u_n, k, rstar)
+    dlc2 = dLightcurve(dt, obs_duration, u_n, k, rstar)
+
     for field in fieldnames(Lightcurve)
         @test getfield(lc1, field) == getfield(lc2, field)
     end
+
+    for field in fieldnames(dLightcurve)
+        @test getfield(dlc1, field) == getfield(dlc2, field)
+    end
+
     return
 end
 


### PR DESCRIPTION
Split up `Lightcurve` into `Lightcurve` and `dLightcurve`. This simplifies the way a user specifies whether to compute derivatives or not. Constructors have identical arguments.